### PR TITLE
feat: Implement trip history and inbox titles with conditional messag…

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,8 @@
         <activity
             android:name=".TripDetailActivity"
             android:exported="false" />
+        <activity android:name=".ChatListActivity" />
+
         <activity
             android:name=".SettingPage"
             android:exported="false" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,6 +24,9 @@
         <activity
             android:name=".SettingPage"
             android:exported="false" />
+        <activity android:name=".InboxPage" android:exported="false" />
+        <activity android:name=".ChatPage" android:exported="false" />
+
         <activity
             android:name=".MessagePage"
             android:exported="false" />

--- a/app/src/main/java/com/example/carpoolingapp/ChatEntry.java
+++ b/app/src/main/java/com/example/carpoolingapp/ChatEntry.java
@@ -1,0 +1,21 @@
+package com.example.carpoolingapp;
+
+import java.io.Serializable;
+
+public class ChatEntry implements Serializable {
+    private final String driverName;
+    private final String lastMessagePreview;
+
+    public ChatEntry(String driverName, String lastMessagePreview) {
+        this.driverName = driverName;
+        this.lastMessagePreview = lastMessagePreview;
+    }
+
+    public String getDriverName() {
+        return driverName;
+    }
+
+    public String getLastMessagePreview() {
+        return lastMessagePreview;
+    }
+}

--- a/app/src/main/java/com/example/carpoolingapp/ChatListActivity.java
+++ b/app/src/main/java/com/example/carpoolingapp/ChatListActivity.java
@@ -1,0 +1,50 @@
+package com.example.carpoolingapp;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.TextView;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import java.util.ArrayList;
+
+public class ChatListActivity extends AppCompatActivity {
+
+    private RecyclerView chatRecyclerView;
+    private ChatListAdapter adapter;
+    private ArrayList<ChatEntry> chatEntries;
+    private TextView noChats;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_chat_list);
+
+        chatRecyclerView = findViewById(R.id.chatRecyclerView);
+        noChats = findViewById(R.id.noChatsText);
+
+        chatEntries = new ArrayList<>();
+        adapter = new ChatListAdapter(chatEntries, entry -> {
+            Intent intent = new Intent(ChatListActivity.this, ChatPage.class);
+            intent.putExtra("driverName", entry.getDriverName());
+            startActivity(intent);
+        });
+
+        chatRecyclerView.setLayoutManager(new LinearLayoutManager(this));
+        chatRecyclerView.setAdapter(adapter);
+
+        loadDummyChats();
+    }
+
+    private void loadDummyChats() {
+        chatEntries.clear();
+        chatEntries.add(new ChatEntry("Daniel Miller", "Hey! Still good for tomorrow?"));
+        chatEntries.add(new ChatEntry("Emma Johnson", "Thanks for the ride!"));
+
+        adapter.notifyDataSetChanged();
+        noChats.setVisibility(chatEntries.isEmpty() ? View.VISIBLE : View.GONE);
+    }
+}

--- a/app/src/main/java/com/example/carpoolingapp/ChatListAdapter.java
+++ b/app/src/main/java/com/example/carpoolingapp/ChatListAdapter.java
@@ -1,0 +1,55 @@
+package com.example.carpoolingapp;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import java.util.List;
+
+public class ChatListAdapter extends RecyclerView.Adapter<ChatListAdapter.ChatViewHolder> {
+
+    private final List<ChatEntry> chatList;
+    private final OnChatClickListener listener;
+
+    public interface OnChatClickListener {
+        void onChatClick(ChatEntry chatEntry);
+    }
+
+    public ChatListAdapter(List<ChatEntry> chatList, OnChatClickListener listener) {
+        this.chatList = chatList;
+        this.listener = listener;
+    }
+
+    @NonNull
+    @Override
+    public ChatViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.item_chat, parent, false);
+        return new ChatViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull ChatViewHolder holder, int position) {
+        ChatEntry entry = chatList.get(position);
+        holder.driverName.setText(entry.getDriverName());
+        holder.lastMessage.setText(entry.getLastMessagePreview());
+        holder.itemView.setOnClickListener(v -> listener.onChatClick(entry));
+    }
+
+    @Override
+    public int getItemCount() {
+        return chatList.size();
+    }
+
+    static class ChatViewHolder extends RecyclerView.ViewHolder {
+        TextView driverName, lastMessage;
+
+        public ChatViewHolder(@NonNull View itemView) {
+            super(itemView);
+            driverName = itemView.findViewById(R.id.chatDriverName);
+            lastMessage = itemView.findViewById(R.id.chatLastMessage);
+        }
+    }
+}

--- a/app/src/main/java/com/example/carpoolingapp/ChatPage.java
+++ b/app/src/main/java/com/example/carpoolingapp/ChatPage.java
@@ -1,0 +1,69 @@
+package com.example.carpoolingapp;
+
+import android.os.Bundle;
+import android.widget.Button;
+import android.widget.EditText;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.Query;
+import com.google.firebase.firestore.QueryDocumentSnapshot;
+
+import java.util.ArrayList;
+import java.util.Date;
+
+public class ChatPage extends AppCompatActivity {
+
+    private String driverName;
+    private FirebaseFirestore db;
+    private ArrayList<Message> messages = new ArrayList<>();
+    private MessageAdapter adapter;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_chat_page);
+
+        driverName = getIntent().getStringExtra("driverName");
+
+        RecyclerView recyclerView = findViewById(R.id.recyclerViewChat);
+        EditText input = findViewById(R.id.editTextChat);
+        Button sendBtn = findViewById(R.id.sendButtonChat);
+
+        db = FirebaseFirestore.getInstance();
+        adapter = new MessageAdapter(messages);
+        recyclerView.setLayoutManager(new LinearLayoutManager(this));
+        recyclerView.setAdapter(adapter);
+
+        loadChatMessages();
+
+        sendBtn.setOnClickListener(v -> {
+            String text = input.getText().toString().trim();
+            if (!text.isEmpty()) {
+                Message message = new Message("You", text, new Date());
+                db.collection("messages").add(message);
+                input.setText("");
+            }
+        });
+    }
+
+    private void loadChatMessages() {
+        db.collection("messages")
+                .orderBy("timestamp", Query.Direction.ASCENDING)
+                .addSnapshotListener((snapshots, e) -> {
+                    if (e != null) return;
+                    messages.clear();
+                    for (QueryDocumentSnapshot doc : snapshots) {
+                        Message msg = doc.toObject(Message.class);
+                        if (driverName.equals(msg.getSender()) || "You".equals(msg.getSender())) {
+                            messages.add(msg);
+                        }
+                    }
+                    adapter.notifyDataSetChanged();
+                });
+    }
+}
+

--- a/app/src/main/java/com/example/carpoolingapp/InboxAdapter.java
+++ b/app/src/main/java/com/example/carpoolingapp/InboxAdapter.java
@@ -1,0 +1,55 @@
+package com.example.carpoolingapp;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import java.util.List;
+
+public class InboxAdapter extends RecyclerView.Adapter<InboxAdapter.ViewHolder> {
+
+    public interface OnDriverClickListener {
+        void onClick(String driverName);
+    }
+
+    private final List<String> driverList;
+    private final OnDriverClickListener listener;
+
+    public InboxAdapter(List<String> driverList, OnDriverClickListener listener) {
+        this.driverList = driverList;
+        this.listener = listener;
+    }
+
+    @NonNull
+    @Override
+    public InboxAdapter.ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext())
+                .inflate(android.R.layout.simple_list_item_1, parent, false);
+        return new ViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull InboxAdapter.ViewHolder holder, int position) {
+        String name = driverList.get(position);
+        holder.textView.setText(name);
+        holder.itemView.setOnClickListener(v -> listener.onClick(name));
+    }
+
+    @Override
+    public int getItemCount() {
+        return driverList.size();
+    }
+
+    public static class ViewHolder extends RecyclerView.ViewHolder {
+        TextView textView;
+
+        public ViewHolder(@NonNull View itemView) {
+            super(itemView);
+            textView = itemView.findViewById(android.R.id.text1);
+        }
+    }
+}

--- a/app/src/main/java/com/example/carpoolingapp/InboxPage.java
+++ b/app/src/main/java/com/example/carpoolingapp/InboxPage.java
@@ -1,0 +1,89 @@
+package com.example.carpoolingapp;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.TextView;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+import com.google.firebase.firestore.DocumentSnapshot;
+
+import com.google.android.material.bottomnavigation.BottomNavigationView;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.QueryDocumentSnapshot;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+
+public class InboxPage extends AppCompatActivity {
+
+    private RecyclerView recyclerView;
+    private InboxAdapter adapter;
+    private TextView textNoMessages;
+    private ArrayList<String> driverNames = new ArrayList<>();
+    private FirebaseFirestore db = FirebaseFirestore.getInstance();
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_inbox_page);
+
+        recyclerView = findViewById(R.id.recyclerViewInbox);
+        textNoMessages = findViewById(R.id.textNoMessages);
+
+        recyclerView.setLayoutManager(new LinearLayoutManager(this));
+        adapter = new InboxAdapter(driverNames, driverName -> {
+            Intent intent = new Intent(InboxPage.this, ChatPage.class);
+            intent.putExtra("driverName", driverName);
+            startActivity(intent);
+        });
+        recyclerView.setAdapter(adapter);
+
+        loadInboxDrivers();
+
+        BottomNavigationView bottomNavigationView = findViewById(R.id.bottom_navigation);
+        bottomNavigationView.setOnNavigationItemSelectedListener(item -> {
+            if (item.getItemId() == R.id.nav_home) {
+                if (!(getClass().equals(MainActivity.class))) {
+                    startActivity(new Intent(this, MainActivity.class));
+                }
+                return true;
+            } else if (item.getItemId() == R.id.nav_chat) {
+                return true; // Already here
+            } else if (item.getItemId() == R.id.nav_settings) {
+                if (!(getClass().equals(SettingPage.class))) {
+                    startActivity(new Intent(this, SettingPage.class));
+                }
+                return true;
+            }
+            return false;
+        });
+    }
+
+    private void loadInboxDrivers() {
+        db.collection("messages").get().addOnSuccessListener(querySnapshot -> {
+            HashSet<String> uniqueDrivers = new HashSet<>();
+            for (DocumentSnapshot doc : querySnapshot.getDocuments()) {
+                String sender = doc.getString("sender");
+                if (!"You".equals(sender)) {
+                    uniqueDrivers.add(sender);
+                }
+            }
+
+            driverNames.clear();
+            driverNames.addAll(uniqueDrivers);
+            adapter.notifyDataSetChanged();
+
+            if (driverNames.isEmpty()) {
+                textNoMessages.setVisibility(View.VISIBLE);
+                recyclerView.setVisibility(View.GONE);
+            } else {
+                textNoMessages.setVisibility(View.GONE);
+                recyclerView.setVisibility(View.VISIBLE);
+            }
+        });
+    }
+
+}

--- a/app/src/main/java/com/example/carpoolingapp/MainActivity.java
+++ b/app/src/main/java/com/example/carpoolingapp/MainActivity.java
@@ -200,12 +200,13 @@ public class MainActivity extends AppCompatActivity {
                 }
                 return true;
             } else if (item.getItemId() == R.id.nav_chat) {
-                if (!(getClass().equals(MessagePage.class))) {
-                    Intent intent = new Intent(MainActivity.this, MessagePage.class);
-                    startActivity(intent);
-                }
-                return true;
-            } else if (item.getItemId() == R.id.nav_settings) {
+            if (!(getClass().equals(InboxPage.class))) {
+                Intent intent = new Intent(MainActivity.this, InboxPage.class);
+                startActivity(intent);
+            }
+            return true;
+        }
+        else if (item.getItemId() == R.id.nav_settings) {
                 Intent intent = new Intent(MainActivity.this, SettingPage.class);
                 intent.putExtra("acceptedDriver", acceptedDriverName);
                 intent.putExtra("selectedDate", selectedDate);

--- a/app/src/main/java/com/example/carpoolingapp/SettingPage.java
+++ b/app/src/main/java/com/example/carpoolingapp/SettingPage.java
@@ -70,8 +70,9 @@ public class SettingPage extends AppCompatActivity {
                 }
                 return true;
             } else if (item.getItemId() == R.id.nav_chat) {
-                if (!(getClass().equals(MessagePage.class))) {
-                    startActivity(new Intent(this, MessagePage.class));
+                if (!(getClass().equals(InboxPage.class))) {
+                    Intent intent = new Intent(SettingPage.this, InboxPage.class);
+                    startActivity(intent);
                 }
                 return true;
             } else if (item.getItemId() == R.id.nav_settings) {

--- a/app/src/main/res/layout/activity_chat_list.xml
+++ b/app/src/main/res/layout/activity_chat_list.xml
@@ -1,0 +1,25 @@
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/noChatsText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="No chats yet"
+        android:textSize="18sp"
+        android:textColor="#888888"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/chatRecyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:padding="12dp"/>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_chat_page.xml
+++ b/app/src/main/res/layout/activity_chat_page.xml
@@ -1,0 +1,33 @@
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerViewChat"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:padding="8dp" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="8dp">
+
+        <EditText
+            android:id="@+id/editTextChat"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content"
+            android:hint="Type message" />
+
+        <Button
+            android:id="@+id/sendButtonChat"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Send" />
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/activity_inbox_page.xml
+++ b/app/src/main/res/layout/activity_inbox_page.xml
@@ -1,0 +1,56 @@
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <!-- Title at the top -->
+    <TextView
+        android:id="@+id/inboxTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Inbox"
+        android:textSize="24sp"
+        android:textStyle="bold"
+        android:layout_marginTop="16dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <!-- "No messages" text -->
+    <TextView
+        android:id="@+id/textNoMessages"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="You have no messages yet."
+        android:textColor="#888888"
+        android:textSize="16sp"
+        android:visibility="gone"
+        app:layout_constraintTop_toBottomOf="@+id/inboxTitle"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <!-- List of chats -->
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerViewInbox"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:padding="12dp"
+        app:layout_constraintTop_toBottomOf="@id/inboxTitle"
+        app:layout_constraintBottom_toTopOf="@+id/bottom_navigation"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <!-- Bottom Navigation -->
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+        android:id="@+id/bottom_navigation"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:layout_marginBottom="8dp"
+        app:menu="@menu/bottom_nav_menu"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_setting_page.xml
+++ b/app/src/main/res/layout/activity_setting_page.xml
@@ -21,6 +21,19 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"/>
 
+    <!-- Trip History Title -->
+    <TextView
+        android:id="@+id/tripHistoryTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Trip History"
+        android:textSize="24sp"
+        android:textStyle="bold"
+        android:layout_marginTop="16dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
     <!-- Empty Message -->
     <TextView
         android:id="@+id/emptyTextView"

--- a/app/src/main/res/layout/item_chat.xml
+++ b/app/src/main/res/layout/item_chat.xml
@@ -1,0 +1,20 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:padding="12dp"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <TextView
+        android:id="@+id/chatDriverName"
+        android:textStyle="bold"
+        android:textSize="16sp"
+        android:text="Driver Name"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"/>
+
+    <TextView
+        android:id="@+id/chatLastMessage"
+        android:text="Last message preview"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"/>
+</LinearLayout>


### PR DESCRIPTION
**Title:**  
`feat: Trip History & Inbox Titles + Empty State Handling`

**Description:**  
Implemented UI enhancements and partial logic for the following:
- Trip History screen now displays a proper title at the top
- Inbox screen now shows a title ("Inbox") and displays a message if no conversations are found
- Refactored how driver names are pulled from Firestore messages
- Logic is complete for both features — just need someone to connect the chat routing fully


**Type of Change:**  
- [x]  New feature  
- [x]  UI update  
- [ ]  Bug fix  
- [ ]  Code cleanup  

**Checklist:**  
- [x] Title/header added for Trip History and Inbox  
- [x] Logic for "no messages" implemented  
- [x] RecyclerView updates dynamically  
- [x] BottomNavigationView is consistent  
- [ ] ChatPage connection needs to be finalized


**Additional Notes:**  
Would love another pair of eyes to finalize how the `InboxAdapter` links to individual chat threads via `ChatPage`.
